### PR TITLE
Fixed 'px' in fallback not appearing

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function postcssUnits(options) {
         node.value = size + type;
 
         if (options.fallback && type === 'rem') {
-          node.fallback = value.number + value.unit;
+          node.fallback = value.number + 'px';
           fallback = true;
         }
       });


### PR DESCRIPTION
When you write a value without the px unit in css (say "margin: rem(40)"), its fallback generated was "margin: 40" (without px).